### PR TITLE
fix: update help.kassellabs.io references to kassellabs.io

### DIFF
--- a/src/js/common/ContactButton.js
+++ b/src/js/common/ContactButton.js
@@ -3,7 +3,7 @@ import React from 'react';
 const ContactButton = ({ customText = 'If you have any questions, please check our FAQ or contact us through the link:' }) => {
   const link = (
     <a
-      href="https://help.kassellabs.io/game-of-thrones/"
+      href="https://kassellabs.io/help/game-of-thrones-intro-creator"
       rel="noopener noreferrer"
       target="_blank"
       className="link"

--- a/src/js/common/NavBar.js
+++ b/src/js/common/NavBar.js
@@ -19,13 +19,13 @@ class NavBar extends Component {
     const menu = (
       <ul className="menu">
         <li><a href="/#/">HOME</a></li>
-        <li><a href="https://help.kassellabs.io/game-of-thrones/">CONTACT</a></li>
+        <li><a href="https://kassellabs.io/contact">CONTACT</a></li>
         <li>
           <a>HELP</a> {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
           <ul className="dropdown">
-            <li><a href="https://help.kassellabs.io/game-of-thrones/">FAQ</a></li>
-            <li><a href="https://help.kassellabs.io/game-of-thrones/#termsOfService">TERMS OF SERVICE</a></li>
-            <li><a href="https://help.kassellabs.io/privacy/">PRIVACY POLICY</a></li>
+            <li><a href="https://kassellabs.io/help/game-of-thrones-intro-creator">FAQ</a></li>
+            <li><a href="https://kassellabs.io/terms">TERMS OF SERVICE</a></li>
+            <li><a href="https://kassellabs.io/privacy">PRIVACY POLICY</a></li>
             <li><a href="https://kassellabs.io/about">ABOUT US</a></li>
           </ul>
         </li>

--- a/src/js/common/TermsOfServiceAcceptance.js
+++ b/src/js/common/TermsOfServiceAcceptance.js
@@ -5,7 +5,7 @@ const TermsOfServiceAcceptance = () => (
     By using this website you are agreeing to our{' '}
     <a
       className="link"
-      href="https://help.kassellabs.io/game-of-thrones/#termsOfService"
+      href="https://kassellabs.io/terms"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -11,4 +11,4 @@
 ## About
 - Created by: Kassel Labs (https://kassellabs.io)
 - URL: https://gameofthronesintrocreator.kassellabs.io/
-- Contact: https://help.kassellabs.io/game-of-thrones/
+- Contact: https://kassellabs.io/help/game-of-thrones-intro-creator


### PR DESCRIPTION
## Summary
- Replace deprecated `help.kassellabs.io` URLs in NavBar, ContactButton, TermsOfServiceAcceptance, and llms.txt
- Point links at the canonical pages on `kassellabs.io`:
  - CONTACT → `https://kassellabs.io/contact`
  - FAQ → `https://kassellabs.io/help/game-of-thrones-intro-creator`
  - TERMS OF SERVICE → `https://kassellabs.io/terms`
  - PRIVACY POLICY → `https://kassellabs.io/privacy`

## Test plan
- [x] Open the deployed site and confirm CONTACT, FAQ, TERMS, and PRIVACY navigate to the new pages
- [x] Confirm the ToS acceptance link on the download page resolves
- [x] Confirm the FAQ/Contact link in ContactButton resolves