### PR TITLE
fix(seo): title says 'GoT Intro, Free' — searchers type 'intro', not 'opening sequence'

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   })(window,document,'script','dataLayer','GTM-MR5NZ7D');</script>
   <!-- End Google Tag Manager -->
 
-  <title>Game of Thrones Intro Creator - Make Your Own Custom Opening Sequence</title>
+  <title>Game of Thrones Intro Creator - Make Your Own GoT Intro, Free</title>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Create your own custom Game of Thrones intro with personalized text. Write your credits, preview the iconic opening sequence, and share it with friends." />


### PR DESCRIPTION
## Context

Search Console (28 days): **"game of thrones intro" sends 1,148 impressions at position 6.0 with 1.0% CTR** (~4% expected at that position, ~35 clicks/period lost). The title tail said "Make Your Own Custom Opening Sequence" — nobody searches "opening sequence".

One-line change in `src/index.html`:
- **Title:** `Game of Thrones Intro Creator - Make Your Own GoT Intro, Free`

Meta/OG descriptions already mention "intro" and are untouched.

## How to Test
View page source after deploy — `<title>` carries the new copy. Track with `npm run gsc-report -- pages-for 'game of thrones intro'` in the kassellabs.io monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)